### PR TITLE
Fixes memory history conversation retrieval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vianexus_agent_sdk"
-version = "1.0.0-pre6"
+version = "1.0.0-pre7"
 authors = [
   { name="viaNexus", email="support@vianexus.com" },
 ]

--- a/src/vianexus_agent_sdk/clients/gemini_client.py
+++ b/src/vianexus_agent_sdk/clients/gemini_client.py
@@ -661,8 +661,15 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         gemini_messages = []
         
         for msg in memory_messages:
-            role = msg.get("role", "user")
-            content = msg.get("content", "")
+            # Handle both UniversalMessage objects and dict formats
+            if hasattr(msg, 'role'):
+                # UniversalMessage object
+                role = msg.role.value if hasattr(msg.role, 'value') else str(msg.role)
+                content = msg.content
+            else:
+                # Dictionary format (fallback)
+                role = msg.get("role", "user")
+                content = msg.get("content", "")
             
             # Map roles to Gemini format
             if role == "assistant":


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert loaded memory history into provider-specific message formats across Anthropic, OpenAI, and Gemini; bump version to `1.0.0-pre7`.
> 
> - **Clients**:
>   - **Anthropic (`src/vianexus_agent_sdk/clients/anthropic_client.py`)**:
>     - Add `_convert_memory_to_anthropic_messages` and use it when loading memory in `ask_question`.
>   - **OpenAI (`src/vianexus_agent_sdk/clients/openai_client.py`)**:
>     - Add `_convert_memory_to_openai_messages` and use it when loading memory in `ask_question`.
>   - **Gemini (`src/vianexus_agent_sdk/clients/gemini_client.py`)**:
>     - Enhance `_convert_memory_to_gemini_messages` to handle `UniversalMessage` objects in addition to dicts.
> - **Version**:
>   - Bump `pyproject.toml` version from `1.0.0-pre6` to `1.0.0-pre7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 854630093e7941e5ff31c5b663597c71a0ad8a94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->