### PR TITLE
Stream LLM responses

### DIFF
--- a/examples/clients/anthropic/streaming_fastapi_sse.py
+++ b/examples/clients/anthropic/streaming_fastapi_sse.py
@@ -1,0 +1,107 @@
+"""
+FastAPI app demonstrating streaming responses via Server-Sent Events (SSE).
+
+Run with:
+    uvicorn examples.clients.anthropic.streaming_fastapi_sse:app --reload
+"""
+import asyncio
+import json
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from vianexus_agent_sdk.clients.anthropic_client import PersistentAnthropicClient
+
+client = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup
+    global client
+    config = {
+        "LLM_API_KEY": "your-anthropic-api-key",
+        "LLM_MODEL": "claude-3-5-sonnet-20241022",
+        "max_tokens": 1000,
+        "user_id": "your-user-id",
+        "app_name": "your-app-name",
+        "agentServers": {
+            "viaNexus": {
+                "server_url": "your-vianexus-server-url",
+                "server_port": 443,
+                "software_statement": "your-software-statement-jwt"
+            }
+        },
+    }
+
+    client = PersistentAnthropicClient(config)
+    session_id = await client.establish_persistent_connection()
+    print(f"Service ready with persistent MCP session: {session_id}")
+
+    yield
+
+    # Shutdown
+    if client:
+        await client.cleanup()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+class AskRequest(BaseModel):
+    question: str
+
+
+@app.post("/ask")
+async def ask(request: AskRequest):
+    """Non-streaming endpoint for comparison."""
+    try:
+        response = await client.ask_with_persistent_session(request.question)
+        return {"response": response}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@app.post("/ask/stream")
+async def ask_stream(request: AskRequest):
+    """
+    Streaming endpoint that returns an SSE stream.
+
+    Events:
+        event: delta  — {"text": "chunk"}   (incremental token)
+        event: done   — {}                  (stream finished)
+    """
+    queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+    # on_delta must be a sync callable (Callable[[str], None])
+    # Use queue.put_nowait since we're already on the event loop
+    def on_delta(chunk: str):
+        queue.put_nowait(chunk)
+
+    async def run_query():
+        try:
+            await client.ask_with_persistent_session(
+                request.question,
+                on_delta=on_delta
+            )
+        except Exception as e:
+            queue.put_nowait(f"__error__:{e}")
+        finally:
+            queue.put_nowait(None)  # sentinel
+
+    asyncio.create_task(run_query())
+
+    async def event_generator():
+        while True:
+            chunk = await queue.get()
+            if chunk is None:
+                yield f"event: done\ndata: {{}}\n\n"
+                break
+            if isinstance(chunk, str) and chunk.startswith("__error__:"):
+                error_msg = chunk[len("__error__:"):]
+                yield f"event: error\ndata: {json.dumps({'error': error_msg})}\n\n"
+                break
+            yield f"event: delta\ndata: {json.dumps({'text': chunk})}\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/examples/clients/anthropic/streaming_responses.py
+++ b/examples/clients/anthropic/streaming_responses.py
@@ -1,0 +1,122 @@
+import asyncio
+from vianexus_agent_sdk.clients.anthropic_client import PersistentAnthropicClient
+
+config = {
+    "LLM_API_KEY": "your-anthropic-api-key",
+    "LLM_MODEL": "claude-3-5-sonnet-20241022",
+    "max_tokens": 1000,
+    "max_history_length": 20,
+    "user_id": "your-user-id",
+    "app_name": "your-app-name",
+    "agentServers": {
+        "viaNexus": {
+            "server_url": "your-vianexus-server-url",
+            "server_port": 443,
+            "software_statement": "your-software-statement-jwt"
+        }
+    },
+}
+
+
+async def basic_streaming_example():
+    """
+    Basic streaming with ask_question().
+    The on_delta callback prints each text chunk as it arrives,
+    giving the user a real-time typewriter effect.
+    """
+    client = PersistentAnthropicClient(config)
+
+    try:
+        await client.establish_persistent_connection()
+
+        print("=== Basic Streaming ===")
+
+        # on_delta is called with each text chunk as it arrives
+        response = await client.ask_question(
+            "What is the current stock price of AAPL?",
+            on_delta=lambda chunk: print(chunk, end="", flush=True)
+        )
+
+        # A newline after streaming finishes
+        print()
+        # The full response is still returned as the function's return value
+        print(f"\nFull response length: {len(response)} chars")
+
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        await client.cleanup()
+
+
+async def persistent_session_streaming_example():
+    """
+    Streaming with a persistent session for multi-turn conversations.
+    Each call to ask_with_persistent_session streams tokens via on_delta
+    while maintaining conversation history across turns.
+    """
+    client = PersistentAnthropicClient(config)
+
+    try:
+        session_id = await client.establish_persistent_connection()
+        print(f"Session: {session_id}\n")
+
+        questions = [
+            "What is the current stock price of AAPL?",
+            "How does that compare to its 52-week high?",
+        ]
+
+        for i, question in enumerate(questions, 1):
+            print(f"=== Turn {i}: {question} ===")
+            response = await client.ask_with_persistent_session(
+                question,
+                maintain_history=True,
+                on_delta=lambda chunk: print(chunk, end="", flush=True)
+            )
+            print("\n")
+
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        await client.cleanup()
+
+
+async def collecting_chunks_example():
+    """
+    Collecting streamed chunks programmatically instead of printing them.
+    Useful when you need to forward chunks to a WebSocket, write to a file,
+    or do any custom processing with the incremental text.
+    """
+    client = PersistentAnthropicClient(config)
+    chunks: list[str] = []
+
+    try:
+        await client.establish_persistent_connection()
+
+        print("=== Collecting Chunks ===")
+
+        response = await client.ask_question(
+            "Give me a brief summary of Tesla's recent performance.",
+            on_delta=lambda chunk: chunks.append(chunk)
+        )
+
+        print(f"Received {len(chunks)} chunks")
+        print(f"Reconstructed response matches return value: {response == ''.join(chunks)}")
+        print(f"First 3 chunks: {chunks[:3]}")
+
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        await client.cleanup()
+
+
+if __name__ == "__main__":
+    print("=== Basic Streaming Example ===")
+    asyncio.run(basic_streaming_example())
+
+    print("\n" + "=" * 50)
+    print("=== Persistent Session Streaming Example ===")
+    asyncio.run(persistent_session_streaming_example())
+
+    print("\n" + "=" * 50)
+    print("=== Collecting Chunks Example ===")
+    asyncio.run(collecting_chunks_example())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vianexus_agent_sdk"
-version = "1.0.0-pre14"
+version = "1.0.0-pre15"
 authors = [
   { name="viaNexus", email="support@vianexus.com" },
 ]

--- a/src/vianexus_agent_sdk/clients/anthropic_client.py
+++ b/src/vianexus_agent_sdk/clients/anthropic_client.py
@@ -6,7 +6,7 @@ import json
 import re
 import ast
 from contextlib import AsyncExitStack
-from typing import Optional
+from typing import Callable, Optional
 
 try:
     import jwt as jwt_lib
@@ -350,16 +350,16 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
         """Clear the captured artifacts list."""
         self._last_artifacts = []
     
-    async def process_query(self, query: str) -> str:
+    async def process_query(self, query: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """
         Process query with streaming output (implements abstract method).
         """
         if not self.session:
             return "Error: MCP session not initialized."
-        
+
         # Clear artifacts from previous conversation turn
         self.clear_artifacts()
-        
+
         tools = await self._get_available_tools()
         self.messages.append({"role": "user", "content": query})
 
@@ -368,7 +368,10 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
             iteration += 1
             if iteration > MAX_TOOL_ITERATIONS:
                 logging.warning(f"Max tool iterations ({MAX_TOOL_ITERATIONS}) reached in process_query, breaking loop")
-                print("\n[Max tool iterations reached]")
+                if on_delta:
+                    on_delta("\n[Max tool iterations reached]")
+                else:
+                    print("\n[Max tool iterations reached]")
                 self._trim_history()
                 return ""
 
@@ -381,7 +384,10 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
             ) as stream:
                 async for event in stream:
                     if event.type == "content_block_delta" and getattr(event.delta, "type", "") == "text_delta":
-                        print(event.delta.text, end="", flush=True)
+                        if on_delta:
+                            on_delta(event.delta.text)
+                        else:
+                            print(event.delta.text, end="", flush=True)
 
                 msg = await stream.get_final_message()
 
@@ -390,7 +396,8 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
             self.messages.append({"role": "assistant", "content": content_blocks})
 
             if not tool_uses:
-                print()
+                if not on_delta:
+                    print()
                 self._trim_history()
                 return ""
 
@@ -423,7 +430,7 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
             args = tub.input if isinstance(tub.input, dict) else {}
 
             try:
-                logging.info(f"Calling tool: {name}")
+                logging.debug(f"Calling tool: {name}")
                 logging.debug(f"Tool args: {json.dumps(args, indent=2, default=str)}")
                 result = await self.session.call_tool(name, args)
                 payload = result.content
@@ -731,11 +738,12 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
         return response_content.strip()
     
     async def ask_question(
-        self, 
-        question: str, 
+        self,
+        question: str,
         maintain_history: bool = False,
         use_memory: bool = False,
-        load_from_memory: bool = True
+        load_from_memory: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question with optional conversation history and memory integration.
@@ -782,13 +790,26 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                     logging.warning(f"Max tool iterations ({MAX_TOOL_ITERATIONS}) reached in ask_question, breaking loop")
                     break
 
-                response = await self.anthropic.messages.create(
-                    model=self.model,
-                    max_tokens=self.max_tokens,
-                    messages=self.messages,
-                    tools=tools or None,
-                    system=self.system_prompt
-                )
+                if on_delta:
+                    async with self.anthropic.messages.stream(
+                        model=self.model,
+                        max_tokens=self.max_tokens,
+                        messages=self.messages,
+                        tools=tools or None,
+                        system=self.system_prompt
+                    ) as stream:
+                        async for event in stream:
+                            if event.type == "content_block_delta" and getattr(event.delta, "type", "") == "text_delta":
+                                on_delta(event.delta.text)
+                        response = await stream.get_final_message()
+                else:
+                    response = await self.anthropic.messages.create(
+                        model=self.model,
+                        max_tokens=self.max_tokens,
+                        messages=self.messages,
+                        tools=tools or None,
+                        system=self.system_prompt
+                    )
 
                 # Extract text content
                 content_blocks, block_response_content = self._process_content_blocks_for_tool_use(response.content)
@@ -1033,21 +1054,23 @@ class PersistentAnthropicClient(BasePersistentLLMClient, AnthropicClient):
         return is_active
     
     async def ask_with_persistent_session(
-        self, 
-        question: str, 
+        self,
+        question: str,
         maintain_history: bool = False,
         use_memory: bool = False,
-        auto_establish_connection: bool = True
+        auto_establish_connection: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question using the persistent MCP connection with integrated memory.
-        
+
         Args:
             question: The question to ask
             maintain_history: Whether to maintain conversation context (default: True)
             use_memory: Whether to use memory for context and persistence (default: True)
             auto_establish_connection: Whether to automatically establish MCP connection if needed (default: True)
-        
+            on_delta: Optional callback invoked with each text chunk as it arrives for streaming.
+
         Returns:
             The response as a string
         """
@@ -1060,21 +1083,22 @@ class PersistentAnthropicClient(BasePersistentLLMClient, AnthropicClient):
                 except Exception as e:
                     logging.error(f"Failed to establish MCP connection: {e}")
                     raise RuntimeError(f"Could not establish persistent MCP connection: {e}")
-        
+
         if not self.is_connected:
             raise RuntimeError("No persistent MCP connection available. Call establish_persistent_connection() first or set auto_establish_connection=True")
-        
+
         if not self.session:
             raise RuntimeError("MCP session not initialized")
-        
+
         # Use the ask_question method which integrates with memory system
         return await self.ask_question(
             question=question,
             maintain_history=maintain_history,
             use_memory=use_memory,
-            load_from_memory=use_memory
+            load_from_memory=use_memory,
+            on_delta=on_delta
         )
-    
+
     async def cleanup(self) -> None:
         """Clean up both persistent and base class resources."""
         await self.close_persistent_connection()

--- a/src/vianexus_agent_sdk/clients/anthropic_client.py
+++ b/src/vianexus_agent_sdk/clients/anthropic_client.py
@@ -652,17 +652,18 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
         
         return processed_blocks, response_content
     
-    async def ask_single_question(self, question: str) -> str:
+    async def ask_single_question(self, question: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """
         Ask a single question without maintaining conversation history.
         Works with both persistent connections and creates temporary connections as needed.
-        
+
         Args:
             question: The question to ask
-            
+            on_delta: Optional callback invoked with each text chunk for streaming.
+
         Returns:
             The response as a string
-            
+
         Raises:
             ValueError: If question is invalid
         """
@@ -673,18 +674,18 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
         # Check if we have a persistent connection
         if hasattr(self, '_connection_active') and self._connection_active and self.session:
             # Use existing persistent connection
-            return await self._ask_single_question_with_session(question)
+            return await self._ask_single_question_with_session(question, on_delta=on_delta)
         else:
             # Create temporary connection for this request
             async with self.connection_manager.connection_context() as (readstream, writestream, get_session_id):
                 self.readstream = readstream
                 self.writestream = writestream
-                
+
                 if not await self.connect_to_server():
                     return "Error: Failed to establish MCP connection."
-                
+
                 try:
-                    return await self._ask_single_question_with_session(question)
+                    return await self._ask_single_question_with_session(question, on_delta=on_delta)
                 finally:
                     # Clean up temporary session
                     if hasattr(self, '_exit_stack') and self._exit_stack:
@@ -694,7 +695,7 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
     
-    async def _ask_single_question_with_session(self, question: str) -> str:
+    async def _ask_single_question_with_session(self, question: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """Helper method that assumes session is already established."""
         # Get available tools
         tools = await self._get_available_tools()
@@ -710,14 +711,27 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
                 logging.warning(f"Max tool iterations ({MAX_TOOL_ITERATIONS}) reached in _ask_single_question_with_session, breaking loop")
                 break
 
-            # Call Anthropic API
-            response = await self.anthropic.messages.create(
-                model=self.model,
-                max_tokens=self.max_tokens,
-                messages=temp_messages,
-                tools=tools or None,
-                system=self.system_prompt
-            )
+            if on_delta:
+                async with self.anthropic.messages.stream(
+                    model=self.model,
+                    max_tokens=self.max_tokens,
+                    messages=temp_messages,
+                    tools=tools or None,
+                    system=self.system_prompt
+                ) as stream:
+                    async for event in stream:
+                        if event.type == "content_block_delta" and getattr(event.delta, "type", "") == "text_delta":
+                            on_delta(event.delta.text)
+                    response = await stream.get_final_message()
+            else:
+                # Call Anthropic API
+                response = await self.anthropic.messages.create(
+                    model=self.model,
+                    max_tokens=self.max_tokens,
+                    messages=temp_messages,
+                    tools=tools or None,
+                    system=self.system_prompt
+                )
 
             # Extract text content
             content_blocks, block_response_content = self._process_content_blocks_for_tool_use(response.content)
@@ -839,15 +853,15 @@ class AnthropicClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin)
             return response_content.strip()
         else:
             # Use single question method (no persistent history)
-            result = await self.ask_single_question(question)
-            
+            result = await self.ask_single_question(question, on_delta=on_delta)
+
             # Still save to memory if requested (for searchability)
             if use_memory:
                 await self.memory_save_message("user", question)
                 await self.memory_save_message("assistant", result)
-            
+
             return result
-    
+
     # Abstract method implementations
     async def initialize(self) -> None:
         """

--- a/src/vianexus_agent_sdk/clients/base_llm_client.py
+++ b/src/vianexus_agent_sdk/clients/base_llm_client.py
@@ -3,7 +3,7 @@ Abstract base class defining the unified LLM client interface.
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Any
+from typing import Callable, Optional, Dict, Any
 from vianexus_agent_sdk.memory import BaseMemoryStore
 import logging
 
@@ -141,7 +141,8 @@ class BaseLLMClient(ABC):
         question: str,
         maintain_history: bool = False,
         use_memory: bool = True,
-        load_from_memory: bool = True
+        load_from_memory: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question with optional conversation history and memory integration.
@@ -158,13 +159,16 @@ class BaseLLMClient(ABC):
         pass
     
     @abstractmethod
-    async def process_query(self, query: str) -> str:
+    async def process_query(self, query: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """
         Process query with streaming output and conversation history.
-        
+
         Args:
             query: The query to process
-            
+            on_delta: Optional callback invoked with each text chunk as it arrives.
+                      When provided, chunks are passed to this callback instead of
+                      being printed to stdout.
+
         Returns:
             Empty string (output is streamed to console)
         """
@@ -224,7 +228,8 @@ class BasePersistentLLMClient(BaseLLMClient):
         question: str,
         maintain_history: bool = True,
         use_memory: bool = True,
-        auto_establish_connection: bool = True
+        auto_establish_connection: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question using the persistent MCP connection with integrated memory.

--- a/src/vianexus_agent_sdk/clients/gemini_client.py
+++ b/src/vianexus_agent_sdk/clients/gemini_client.py
@@ -411,60 +411,96 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
 
         while True:
             try:
-                response = await self.client.aio.models.generate_content(
-                    model=self._model_name,
-                    contents=self.messages,
-                    config=genai.types.GenerateContentConfig(
-                        temperature=0.7,
-                        max_output_tokens=self.max_tokens,
-                        system_instruction=self.system_prompt,
-                        tools=[tools] if tools else None
-                    )
-                )
+                if on_delta:
+                    # Streaming branch — incremental token delivery
+                    text_chunks = []
+                    tool_calls = []
+                    async for chunk in await self.client.aio.models.generate_content_stream(
+                        model=self._model_name,
+                        contents=self.messages,
+                        config=genai.types.GenerateContentConfig(
+                            temperature=0.7,
+                            max_output_tokens=self.max_tokens,
+                            system_instruction=self.system_prompt,
+                            tools=[tools] if tools else None
+                        )
+                    ):
+                        if chunk.text:
+                            on_delta(chunk.text)
+                            text_chunks.append(chunk.text)
+                        if chunk.candidates and chunk.candidates[0].content:
+                            for part in (chunk.candidates[0].content.parts or []):
+                                if hasattr(part, 'function_call') and part.function_call:
+                                    tool_calls.append(part.function_call)
 
-                # Check for a text response first
-                logging.info(f"Usage Metadata: {response.usage_metadata}")
-                if response.text:
-                    if on_delta:
-                        on_delta(response.text)
-                    else:
-                        print(response.text, end="", flush=True)
-                    self.messages.append(genai.types.Content(
-                        role="model",
-                        parts=[genai.types.Part.from_text(text=response.text)]
-                    ))
-                    if not on_delta:
-                        print()  # Add newline
-                    self._trim_history()
-                    return ""
-
-                # Check if the response contains content, to prevent NoneType error
-                if response.candidates and response.candidates[0].content:
-                    # Check if the model is calling a tool
-                    content_parts = response.candidates[0].content.parts or []
-                    tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
+                    chunk_text = "".join(text_chunks)
+                    if chunk_text:
+                        self.messages.append(genai.types.Content(
+                            role="model",
+                            parts=[genai.types.Part.from_text(text=chunk_text)]
+                        ))
+                        self._trim_history()
+                        return ""
 
                     if tool_calls:
-                        # Add the model's response to the history (preserving function calls for context)
-                        assistant_content = self._extract_text_only_content(response.candidates[0].content)
-                        if assistant_content:
-                            self.messages.append(assistant_content)
-
-                        # Execute tools
                         tool_results = await self._execute_tool_calls(tool_calls)
                         self.messages.append(genai.types.Content(role="user", parts=tool_results))
                     else:
-                        # Handle cases where there is content, but it's not a text or tool call
-                        logging.warning("Unexpected content format in Gemini response")
+                        logging.warning("Streaming response had no text and no tool calls")
                         self._trim_history()
                         return "No valid response content received from Gemini API"
                 else:
-                    # Handle the 'None' content case
-                    finish_reason = response.candidates[0].finish_reason if response.candidates else "unknown"
-                    logging.warning(f"Model response has no content. Finish reason: {finish_reason}")
-                    self._trim_history()
-                    return f"No response content available. Finish reason: {finish_reason}"
-                    
+                    # Non-streaming branch
+                    response = await self.client.aio.models.generate_content(
+                        model=self._model_name,
+                        contents=self.messages,
+                        config=genai.types.GenerateContentConfig(
+                            temperature=0.7,
+                            max_output_tokens=self.max_tokens,
+                            system_instruction=self.system_prompt,
+                            tools=[tools] if tools else None
+                        )
+                    )
+
+                    # Check for a text response first
+                    logging.info(f"Usage Metadata: {response.usage_metadata}")
+                    if response.text:
+                        print(response.text, end="", flush=True)
+                        self.messages.append(genai.types.Content(
+                            role="model",
+                            parts=[genai.types.Part.from_text(text=response.text)]
+                        ))
+                        print()  # Add newline
+                        self._trim_history()
+                        return ""
+
+                    # Check if the response contains content, to prevent NoneType error
+                    if response.candidates and response.candidates[0].content:
+                        # Check if the model is calling a tool
+                        content_parts = response.candidates[0].content.parts or []
+                        tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
+
+                        if tool_calls:
+                            # Add the model's response to the history (preserving function calls for context)
+                            assistant_content = self._extract_text_only_content(response.candidates[0].content)
+                            if assistant_content:
+                                self.messages.append(assistant_content)
+
+                            # Execute tools
+                            tool_results = await self._execute_tool_calls(tool_calls)
+                            self.messages.append(genai.types.Content(role="user", parts=tool_results))
+                        else:
+                            # Handle cases where there is content, but it's not a text or tool call
+                            logging.warning("Unexpected content format in Gemini response")
+                            self._trim_history()
+                            return "No valid response content received from Gemini API"
+                    else:
+                        # Handle the 'None' content case
+                        finish_reason = response.candidates[0].finish_reason if response.candidates else "unknown"
+                        logging.warning(f"Model response has no content. Finish reason: {finish_reason}")
+                        self._trim_history()
+                        return f"No response content available. Finish reason: {finish_reason}"
+
             except Exception as e:
                 logging.error(f"Error in process_query: {e}")
                 return f"Error processing query: {e}"
@@ -518,7 +554,7 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         return tool_results
     
 
-    async def ask_single_question(self, question: str) -> str:
+    async def ask_single_question(self, question: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """
         Ask a single question without maintaining conversation history.
         Works with both persistent connections and creates temporary connections as needed.
@@ -526,18 +562,18 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         # Check if we have a persistent connection
         if hasattr(self, '_connection_active') and self._connection_active and self.session:
             # Use existing persistent connection
-            return await self._ask_single_question_with_session(question)
+            return await self._ask_single_question_with_session(question, on_delta=on_delta)
         else:
             # Create temporary connection for this request
             async with self.connection_manager.connection_context() as (readstream, writestream, get_session_id):
                 self.readstream = readstream
                 self.writestream = writestream
-                
+
                 if not await self.connect_to_server():
                     return "Error: Failed to establish MCP connection."
-                
+
                 try:
-                    return await self._ask_single_question_with_session(question)
+                    return await self._ask_single_question_with_session(question, on_delta=on_delta)
                 finally:
                     # Clean up temporary session
                     if hasattr(self, '_exit_stack') and self._exit_stack:
@@ -546,53 +582,90 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                             self.session = None
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
-    
-    async def _ask_single_question_with_session(self, question: str) -> str:
+
+    async def _ask_single_question_with_session(self, question: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """Helper method that assumes session is already established."""
         # Get available tools
         tools = await self._get_available_tools()
-        
+
         # Create temporary message list for this single question
         temp_messages = [genai.types.Content(role="user", parts=[genai.types.Part.from_text(text=question)])]
         response_content = ""
-        
+
         while True:
             try:
-                response = await self.client.aio.models.generate_content(
-                    model=self._model_name,
-                    contents=temp_messages,
-                    config=genai.types.GenerateContentConfig(
-                        temperature=0.7,
-                        max_output_tokens=self.max_tokens,
-                        system_instruction=self.system_prompt,
-                        tools=[tools] if tools else None
-                    )
-                )
-                # Extract text content
-                logging.info(f"Usage Metadata: {response.usage_metadata}")
-                if response.text:
-                    response_content += response.text
-                
-                # Check for tool calls
-                if response.candidates and response.candidates[0].content:
-                    content_parts = response.candidates[0].content.parts or []
-                    tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
+                if on_delta:
+                    # Streaming branch
+                    text_chunks = []
+                    tool_calls = []
+                    async for chunk in await self.client.aio.models.generate_content_stream(
+                        model=self._model_name,
+                        contents=temp_messages,
+                        config=genai.types.GenerateContentConfig(
+                            temperature=0.7,
+                            max_output_tokens=self.max_tokens,
+                            system_instruction=self.system_prompt,
+                            tools=[tools] if tools else None
+                        )
+                    ):
+                        if chunk.text:
+                            on_delta(chunk.text)
+                            text_chunks.append(chunk.text)
+                        if chunk.candidates and chunk.candidates[0].content:
+                            for part in (chunk.candidates[0].content.parts or []):
+                                if hasattr(part, 'function_call') and part.function_call:
+                                    tool_calls.append(part.function_call)
+
+                    chunk_text = "".join(text_chunks)
+                    if chunk_text:
+                        response_content += chunk_text
+                        temp_messages.append(genai.types.Content(
+                            role="model",
+                            parts=[genai.types.Part.from_text(text=chunk_text)]
+                        ))
+
                     if not tool_calls:
                         break
-                    
-                    # Add model response to temp conversation (only if content exists)
-                    if response.candidates[0].content:
-                        temp_messages.append(response.candidates[0].content)
-                    # Execute tools
+
                     tool_results = await self._execute_tool_calls(tool_calls)
                     temp_messages.append(genai.types.Content(role="user", parts=tool_results))
                 else:
-                    break
-                    
+                    # Non-streaming branch
+                    response = await self.client.aio.models.generate_content(
+                        model=self._model_name,
+                        contents=temp_messages,
+                        config=genai.types.GenerateContentConfig(
+                            temperature=0.7,
+                            max_output_tokens=self.max_tokens,
+                            system_instruction=self.system_prompt,
+                            tools=[tools] if tools else None
+                        )
+                    )
+                    # Extract text content
+                    logging.info(f"Usage Metadata: {response.usage_metadata}")
+                    if response.text:
+                        response_content += response.text
+
+                    # Check for tool calls
+                    if response.candidates and response.candidates[0].content:
+                        content_parts = response.candidates[0].content.parts or []
+                        tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
+                        if not tool_calls:
+                            break
+
+                        # Add model response to temp conversation (only if content exists)
+                        if response.candidates[0].content:
+                            temp_messages.append(response.candidates[0].content)
+                        # Execute tools
+                        tool_results = await self._execute_tool_calls(tool_calls)
+                        temp_messages.append(genai.types.Content(role="user", parts=tool_results))
+                    else:
+                        break
+
             except Exception as e:
                 logging.error(f"Error in ask_single_question: {e}")
                 return f"Error: {e}"
-        
+
         return response_content.strip()
     
     async def ask_question(
@@ -636,50 +709,100 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             
             while True:
                 try:
-                    response = await self.client.aio.models.generate_content(
-                        model=self._model_name,
-                        contents=self.messages,
-                        config=genai.types.GenerateContentConfig(
-                            temperature=0.7,
-                            max_output_tokens=self.max_tokens,
-                            system_instruction=self.system_prompt,
-                            tools=[tools] if tools else None
-                        )
-                    )
-                    # Log usage metadata
-                    logging.info(f"Usage Metadata: {response.usage_metadata}")
-                    # Extract text content
-                    if response.text:
-                        response_content += response.text
+                    if on_delta:
+                        # Streaming branch
+                        text_chunks = []
+                        tool_calls = []
+                        async for chunk in await self.client.aio.models.generate_content_stream(
+                            model=self._model_name,
+                            contents=self.messages,
+                            config=genai.types.GenerateContentConfig(
+                                temperature=0.7,
+                                max_output_tokens=self.max_tokens,
+                                system_instruction=self.system_prompt,
+                                tools=[tools] if tools else None
+                            )
+                        ):
+                            if chunk.text:
+                                on_delta(chunk.text)
+                                text_chunks.append(chunk.text)
+                            # Collect function calls from chunks
+                            if chunk.candidates and chunk.candidates[0].content:
+                                for part in (chunk.candidates[0].content.parts or []):
+                                    if hasattr(part, 'function_call') and part.function_call:
+                                        tool_calls.append(part.function_call)
 
-                    # Add model response to conversation (preserving function calls for context)
-                    if response.candidates and response.candidates[0].content:
-                        model_content = self._extract_text_only_content(response.candidates[0].content)
-                        if model_content:
-                            self.messages.append(model_content)
-                        
-                        # Save model response to memory
-                        if use_memory and response_content:
-                            await self.memory_save_message("model", response_content)
-                        
-                        # Check for tool calls
-                        content_parts = response.candidates[0].content.parts or []
-                        tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
+                        chunk_text = "".join(text_chunks)
+                        if chunk_text:
+                            response_content += chunk_text
+
+                        # Add model response to conversation
+                        if chunk_text:
+                            self.messages.append(genai.types.Content(
+                                role="model",
+                                parts=[genai.types.Part.from_text(text=chunk_text)]
+                            ))
+
+                        if use_memory and chunk_text:
+                            await self.memory_save_message("model", chunk_text)
+
                         if not tool_calls:
                             break
-                        
+
                         # Execute tools
                         tool_results = await self._execute_tool_calls(tool_calls)
                         self.messages.append(genai.types.Content(role="user", parts=tool_results))
-                        
-                        # Save tool results to memory
+
                         if use_memory:
                             for result_part in tool_results:
                                 if hasattr(result_part, 'function_response'):
                                     await self.memory_save_message("user", str(result_part.function_response), "tool_result")
                     else:
-                        break
-                        
+                        # Non-streaming branch
+                        response = await self.client.aio.models.generate_content(
+                            model=self._model_name,
+                            contents=self.messages,
+                            config=genai.types.GenerateContentConfig(
+                                temperature=0.7,
+                                max_output_tokens=self.max_tokens,
+                                system_instruction=self.system_prompt,
+                                tools=[tools] if tools else None
+                            )
+                        )
+                        # Log usage metadata
+                        logging.info(f"Usage Metadata: {response.usage_metadata}")
+                        # Extract text content
+                        if response.text:
+                            response_content += response.text
+
+                        # Add model response to conversation (preserving function calls for context)
+                        if response.candidates and response.candidates[0].content:
+                            model_content = self._extract_text_only_content(response.candidates[0].content)
+                            if model_content:
+                                self.messages.append(model_content)
+
+                            # Save model response to memory
+                            if use_memory and response_content:
+                                await self.memory_save_message("model", response_content)
+
+                            # Check for tool calls
+                            content_parts = response.candidates[0].content.parts or []
+                            tool_calls = [p.function_call for p in content_parts if hasattr(p, 'function_call') and p.function_call]
+                            if not tool_calls:
+                                break
+
+                            # Execute tools
+                            tool_results = await self._execute_tool_calls(tool_calls)
+                            self.messages.append(genai.types.Content(role="user", parts=tool_results))
+
+                            # Save tool results to memory
+                            if use_memory:
+                                for result_part in tool_results:
+                                    if hasattr(result_part, 'function_response'):
+                                        await self.memory_save_message("user", str(result_part.function_response), "tool_result")
+                        else:
+                            break
+
                 except Exception as e:
                     logging.error(f"Error in ask_question: {e}")
                     return f"Error: {e}"
@@ -688,15 +811,15 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             return response_content.strip()
         else:
             # Use single question method (no persistent history)
-            result = await self.ask_single_question(question)
-            
+            result = await self.ask_single_question(question, on_delta=on_delta)
+
             # Still save to memory if requested (for searchability)
             if use_memory:
                 await self.memory_save_message("user", question)
                 await self.memory_save_message("model", result)
-            
+
             return result
-    
+
     def _extract_text_only_content(self, response_content: 'genai.types.Content') -> Optional['genai.types.Content']:
         """
         Extract text and function call parts from a Gemini response content.
@@ -1015,7 +1138,7 @@ class PersistentGeminiClient(BasePersistentLLMClient, GeminiClient):
             maintain_history: Whether to maintain conversation context (default: True)
             use_memory: Whether to use memory for context and persistence (default: True)
             auto_establish_connection: Whether to automatically establish MCP connection if needed (default: True)
-            on_delta: Optional callback invoked with each text chunk (not yet implemented for Gemini).
+            on_delta: Optional callback invoked with each text chunk for streaming.
 
         Returns:
             The response as a string

--- a/src/vianexus_agent_sdk/clients/gemini_client.py
+++ b/src/vianexus_agent_sdk/clients/gemini_client.py
@@ -7,7 +7,7 @@ import logging
 import base64
 from contextlib import AsyncExitStack
 from google import genai
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 try:
     import jwt as jwt_lib
 except ImportError:
@@ -374,7 +374,7 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             logging.error(f"Error listing tools: {e}")
             return None
 
-    async def process_query(self, query: str) -> str:
+    async def process_query(self, query: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """
         Process query with streaming output (implements abstract method).
         Maintains conversation history like other clients.
@@ -383,18 +383,18 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         # Check if we have a persistent connection
         if hasattr(self, '_connection_active') and self._connection_active and self.session:
             # Use existing persistent connection
-            return await self._process_query_with_session(query)
+            return await self._process_query_with_session(query, on_delta=on_delta)
         else:
             # Create temporary connection for this request
             async with self.connection_manager.connection_context() as (readstream, writestream, get_session_id):
                 self.readstream = readstream
                 self.writestream = writestream
-                
+
                 if not await self.connect_to_server():
                     return "Error: Failed to establish MCP connection."
-                
+
                 try:
-                    return await self._process_query_with_session(query)
+                    return await self._process_query_with_session(query, on_delta=on_delta)
                 finally:
                     # Clean up temporary session
                     if hasattr(self, '_exit_stack') and self._exit_stack:
@@ -404,7 +404,7 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
     
-    async def _process_query_with_session(self, query: str) -> str:
+    async def _process_query_with_session(self, query: str, on_delta=None) -> str:
         """Helper method that assumes session is already established."""
         tools = await self._get_available_tools()
         self.messages.append(genai.types.Content(role="user", parts=[genai.types.Part.from_text(text=query)]))
@@ -425,12 +425,16 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                 # Check for a text response first
                 logging.info(f"Usage Metadata: {response.usage_metadata}")
                 if response.text:
-                    print(response.text, end="", flush=True)
+                    if on_delta:
+                        on_delta(response.text)
+                    else:
+                        print(response.text, end="", flush=True)
                     self.messages.append(genai.types.Content(
-                        role="model", 
+                        role="model",
                         parts=[genai.types.Part.from_text(text=response.text)]
                     ))
-                    print()  # Add newline
+                    if not on_delta:
+                        print()  # Add newline
                     self._trim_history()
                     return ""
 
@@ -592,11 +596,12 @@ class GeminiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         return response_content.strip()
     
     async def ask_question(
-        self, 
-        question: str, 
+        self,
+        question: str,
         maintain_history: bool = False,
         use_memory: bool = False,
-        load_from_memory: bool = True
+        load_from_memory: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question with optional conversation history and memory integration.
@@ -995,21 +1000,23 @@ class PersistentGeminiClient(BasePersistentLLMClient, GeminiClient):
         return is_active
     
     async def ask_with_persistent_session(
-        self, 
-        question: str, 
+        self,
+        question: str,
         maintain_history: bool = False,
         use_memory: bool = False,
-        auto_establish_connection: bool = True
+        auto_establish_connection: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question using the persistent MCP connection with integrated memory.
-        
+
         Args:
             question: The question to ask
             maintain_history: Whether to maintain conversation context (default: True)
             use_memory: Whether to use memory for context and persistence (default: True)
             auto_establish_connection: Whether to automatically establish MCP connection if needed (default: True)
-        
+            on_delta: Optional callback invoked with each text chunk (not yet implemented for Gemini).
+
         Returns:
             The response as a string
         """
@@ -1022,19 +1029,20 @@ class PersistentGeminiClient(BasePersistentLLMClient, GeminiClient):
                 except Exception as e:
                     logging.error(f"Failed to establish MCP connection: {e}")
                     raise RuntimeError(f"Could not establish persistent MCP connection: {e}")
-        
+
         if not self.is_connected:
             raise RuntimeError("No persistent MCP connection available. Call establish_persistent_connection() first or set auto_establish_connection=True")
-        
+
         if not self.session:
             raise RuntimeError("MCP session not initialized")
-        
+
         # Use the ask_question method which integrates with memory system
         return await self.ask_question(
             question=question,
             maintain_history=maintain_history,
             use_memory=use_memory,
-            load_from_memory=use_memory
+            load_from_memory=use_memory,
+            on_delta=on_delta
         )
     
     async def cleanup(self) -> None:

--- a/src/vianexus_agent_sdk/clients/openai_client.py
+++ b/src/vianexus_agent_sdk/clients/openai_client.py
@@ -7,7 +7,7 @@ import logging
 import base64
 from contextlib import AsyncExitStack
 from openai import AsyncOpenAI
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 try:
     import jwt as jwt_lib
 except ImportError:
@@ -348,7 +348,7 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             logging.error("Error listing tools: %s", e)
             return []
 
-    async def _stream_assistant(self, input_text, tools, timeout=60):
+    async def _stream_assistant(self, input_text, tools, timeout=60, on_delta=None):
         """Stream assistant response with tool call handling using responses API"""
         text_out = []
         pending = {}
@@ -369,7 +369,10 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             if hasattr(event, 'type'):
                 if event.type == 'response.text.delta':
                     if hasattr(event, 'delta') and event.delta:
-                        print(event.delta, end="", flush=True)
+                        if on_delta:
+                            on_delta(event.delta)
+                        else:
+                            print(event.delta, end="", flush=True)
                         text_out.append(event.delta)
                 elif event.type == 'response.tool_calls.delta':
                     # Handle tool call deltas from responses API
@@ -461,7 +464,7 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         
         return result_blocks
 
-    async def process_query(self, query: str) -> str:
+    async def process_query(self, query: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """
         Process query with streaming output (implements abstract method).
         Maintains conversation history like Anthropic client.
@@ -479,13 +482,14 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             ])
             current_input = conversation_context
 
-            text, tool_calls, assistant_msg = await self._stream_assistant(current_input, tools)
-            
+            text, tool_calls, assistant_msg = await self._stream_assistant(current_input, tools, on_delta=on_delta)
+
             # Store assistant message in conversation history
             self.messages.append({"role": "assistant", "content": text})
 
             if not tool_calls:
-                print()
+                if not on_delta:
+                    print()
                 self._trim_history()
                 return ""
 
@@ -600,11 +604,12 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         return response_content.strip()
 
     async def ask_question(
-        self, 
-        question: str, 
+        self,
+        question: str,
         maintain_history: bool = False,
         use_memory: bool = False,
-        load_from_memory: bool = True
+        load_from_memory: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question with optional conversation history and memory integration.
@@ -910,21 +915,23 @@ class PersistentOpenAiClient(BasePersistentLLMClient, OpenAiClient):
         return is_active
     
     async def ask_with_persistent_session(
-        self, 
-        question: str, 
+        self,
+        question: str,
         maintain_history: bool = False,
         use_memory: bool = False,
-        auto_establish_connection: bool = True
+        auto_establish_connection: bool = True,
+        on_delta: Optional[Callable[[str], None]] = None
     ) -> str:
         """
         Ask a question using the persistent MCP connection with integrated memory.
-        
+
         Args:
             question: The question to ask
             maintain_history: Whether to maintain conversation context (default: True)
             use_memory: Whether to use memory for context and persistence (default: True)
             auto_establish_connection: Whether to automatically establish MCP connection if needed (default: True)
-        
+            on_delta: Optional callback invoked with each text chunk (not yet implemented for OpenAI).
+
         Returns:
             The response as a string
         """
@@ -938,20 +945,21 @@ class PersistentOpenAiClient(BasePersistentLLMClient, OpenAiClient):
                 except Exception as e:
                     logging.error(f"Failed to establish MCP connection: {e}")
                     raise RuntimeError(f"Could not establish persistent MCP connection: {e}")
-        
+
         if not self.is_connected:
             raise RuntimeError("No persistent MCP connection available. Call establish_persistent_connection() first or set auto_establish_connection=True")
-        
+
         if not self.session:
             raise RuntimeError("MCP session not initialized")
-        
+
         # Use the ask_question method which integrates with memory system
         logging.info(f"Asking question: {question}")
         return await self.ask_question(
             question=question,
             maintain_history=maintain_history,
             use_memory=use_memory,
-            load_from_memory=use_memory
+            load_from_memory=use_memory,
+            on_delta=on_delta
         )
     
     async def cleanup(self) -> None:

--- a/src/vianexus_agent_sdk/clients/openai_client.py
+++ b/src/vianexus_agent_sdk/clients/openai_client.py
@@ -532,7 +532,7 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         if len(self.messages) > self.max_history_length:
             self.messages = self.messages[-self.max_history_length:]
 
-    async def ask_single_question(self, question: str) -> str:
+    async def ask_single_question(self, question: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """
         Ask a single question without maintaining conversation history.
         Works with both persistent connections and creates temporary connections as needed.
@@ -540,18 +540,18 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
         # Check if we have a persistent connection
         if hasattr(self, '_connection_active') and self._connection_active and self.session:
             # Use existing persistent connection
-            return await self._ask_single_question_with_session(question)
+            return await self._ask_single_question_with_session(question, on_delta=on_delta)
         else:
             # Create temporary connection for this request
             async with self.connection_manager.connection_context() as (readstream, writestream, get_session_id):
                 self.readstream = readstream
                 self.writestream = writestream
-                
+
                 if not await self.connect_to_server():
                     return "Error: Failed to establish MCP connection."
-                
+
                 try:
-                    return await self._ask_single_question_with_session(question)
+                    return await self._ask_single_question_with_session(question, on_delta=on_delta)
                 finally:
                     # Clean up temporary session
                     if hasattr(self, '_exit_stack') and self._exit_stack:
@@ -560,47 +560,57 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                             self.session = None
                         except Exception as e:
                             logging.debug(f"Error closing temporary session: {e}")
-    
-    async def _ask_single_question_with_session(self, question: str) -> str:
+
+    async def _ask_single_question_with_session(self, question: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """Helper method that assumes session is already established."""
         # Get available tools
         tools = await self._get_available_tools()
 
         logging.info(f"Tools: {tools}")
-        
+
         response_content = ""
         current_input = question
-        
+
         while True:
-            # Call OpenAI responses API (non-streaming for single questions)
-            response = await self.openai.responses.create(
-                model=self.model,
-                max_output_tokens=self.max_tokens,
-                input=current_input,
-                instructions=self.system_prompt,
-                tools=tools or None
-            )
-            
-            # Extract text content from responses API
-            if hasattr(response, 'output') and response.output:
-                if hasattr(response.output, 'content'):
-                    response_content += response.output.content
-            
-            # Check for tool calls in responses API format
-            if not hasattr(response, 'tool_calls') or not response.tool_calls:
-                break
-            
-            # Execute tools
-            tool_calls_by_id = {tc.id: {
-                "function": {"name": tc.function.name, "arguments": tc.function.arguments}
-            } for tc in response.tool_calls}
-            
+            if on_delta:
+                # Streaming branch
+                text, tool_calls_by_id, _ = await self._stream_assistant(
+                    current_input, tools, on_delta=on_delta
+                )
+                response_content += text
+
+                if not tool_calls_by_id:
+                    break
+            else:
+                # Call OpenAI responses API (non-streaming for single questions)
+                response = await self.openai.responses.create(
+                    model=self.model,
+                    max_output_tokens=self.max_tokens,
+                    input=current_input,
+                    instructions=self.system_prompt,
+                    tools=tools or None
+                )
+
+                # Extract text content from responses API
+                if hasattr(response, 'output') and response.output:
+                    if hasattr(response.output, 'content'):
+                        response_content += response.output.content
+
+                # Check for tool calls in responses API format
+                if not hasattr(response, 'tool_calls') or not response.tool_calls:
+                    break
+
+                # Execute tools
+                tool_calls_by_id = {tc.id: {
+                    "function": {"name": tc.function.name, "arguments": tc.function.arguments}
+                } for tc in response.tool_calls}
+
             result_blocks = await self._execute_tool_calls(tool_calls_by_id)
-            
+
             # Add tool results to input for next iteration
             tool_results = "\n".join([f"Tool result: {result['content']}" for result in result_blocks])
             current_input = f"{current_input}\n{tool_results}"
-        
+
         return response_content.strip()
 
     async def ask_question(
@@ -647,51 +657,70 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
                 conversation_context = "\n".join([
                     f"{msg['role']}: {msg['content']}" for msg in self.messages[-10:]  # Last 10 messages
                 ])
-                
+
                 logging.info(f"Tools: {tools[0] if tools else 'No tools available'}")
-                
-                response = await self.openai.responses.create(
-                    model=self.model,
-                    max_output_tokens=self.max_tokens,
-                    input=conversation_context,
-                    instructions=self.system_prompt,
-                    tools=tools or None
-                )
-                
-                # Extract content from responses API
-                assistant_content = ""
-                if hasattr(response, 'output') and response.output:
-                    if hasattr(response.output, 'content'):
-                        assistant_content = response.output.content
-                        response_content += assistant_content
-                
-                self.messages.append({
-                    "role": "assistant", 
-                    "content": assistant_content
-                })
-                
-                # Save assistant response to memory
-                if use_memory:
-                    await self.memory_save_message("assistant", assistant_content)
-                
-                # Check for tool calls in responses API format
-                if not hasattr(response, 'tool_calls') or not response.tool_calls:
-                    break
-                
-                # Execute tools
-                tool_calls_by_id = {tc.id: {
-                    "function": {"name": tc.function.name, "arguments": tc.function.arguments}
-                } for tc in response.tool_calls}
-                
+
+                if on_delta:
+                    # Streaming branch — reuse _stream_assistant()
+                    assistant_content, tool_calls_by_id, _ = await self._stream_assistant(
+                        conversation_context, tools, on_delta=on_delta
+                    )
+                    response_content += assistant_content
+
+                    self.messages.append({
+                        "role": "assistant",
+                        "content": assistant_content
+                    })
+
+                    if use_memory:
+                        await self.memory_save_message("assistant", assistant_content)
+
+                    if not tool_calls_by_id:
+                        break
+                else:
+                    # Non-streaming branch
+                    response = await self.openai.responses.create(
+                        model=self.model,
+                        max_output_tokens=self.max_tokens,
+                        input=conversation_context,
+                        instructions=self.system_prompt,
+                        tools=tools or None
+                    )
+
+                    # Extract content from responses API
+                    assistant_content = ""
+                    if hasattr(response, 'output') and response.output:
+                        if hasattr(response.output, 'content'):
+                            assistant_content = response.output.content
+                            response_content += assistant_content
+
+                    self.messages.append({
+                        "role": "assistant",
+                        "content": assistant_content
+                    })
+
+                    # Save assistant response to memory
+                    if use_memory:
+                        await self.memory_save_message("assistant", assistant_content)
+
+                    # Check for tool calls in responses API format
+                    if not hasattr(response, 'tool_calls') or not response.tool_calls:
+                        break
+
+                    # Execute tools
+                    tool_calls_by_id = {tc.id: {
+                        "function": {"name": tc.function.name, "arguments": tc.function.arguments}
+                    } for tc in response.tool_calls}
+
                 result_blocks = await self._execute_tool_calls(tool_calls_by_id)
-                
+
                 # Add tool results to conversation
                 for result in result_blocks:
                     self.messages.append({
                         "role": "user",
                         "content": f"Tool result: {result['content']}"
                     })
-                    
+
                     # Save tool results to memory
                     if use_memory:
                         await self.memory_save_message("user", result['content'], "tool_result")
@@ -700,15 +729,15 @@ class OpenAiClient(BaseLLMClient, EnhancedMCPClient, ConversationMemoryMixin):
             return response_content.strip()
         else:
             # Use single question method (no persistent history)
-            result = await self.ask_single_question(question)
-            
+            result = await self.ask_single_question(question, on_delta=on_delta)
+
             # Still save to memory if requested (for searchability)
             if use_memory:
                 await self.memory_save_message("user", question)
                 await self.memory_save_message("assistant", result)
-            
+
             return result
-    
+
     # Abstract method implementations
     async def initialize(self) -> None:
         """
@@ -930,7 +959,7 @@ class PersistentOpenAiClient(BasePersistentLLMClient, OpenAiClient):
             maintain_history: Whether to maintain conversation context (default: True)
             use_memory: Whether to use memory for context and persistence (default: True)
             auto_establish_connection: Whether to automatically establish MCP connection if needed (default: True)
-            on_delta: Optional callback invoked with each text chunk (not yet implemented for OpenAI).
+            on_delta: Optional callback invoked with each text chunk for streaming.
 
         Returns:
             The response as a string

--- a/src/vianexus_agent_sdk/mcp_client/base_mcp_client.py
+++ b/src/vianexus_agent_sdk/mcp_client/base_mcp_client.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from mcp import ClientSession
 
@@ -86,7 +86,7 @@ class BaseMCPClient(ABC):
                 logging.error("Chat loop error: %s", e)
 
     @abstractmethod
-    async def process_query(self, query: str) -> str:
+    async def process_query(self, query: str, on_delta: Optional[Callable[[str], None]] = None) -> str:
         """Implement model/tool-specific query handling."""
         raise NotImplementedError
 

--- a/uv.lock
+++ b/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vianexus-agent-sdk"
-version = "1.0.0rc13"
+version = "1.0.0rc14"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -1133,7 +1133,7 @@ wheels = [
 
 [[package]]
 name = "vianexus-agent-sdk"
-version = "1.0.0rc14"
+version = "1.0.0rc15"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core client request/streaming paths across three providers, so regressions could affect response assembly and tool-call loops; changes are additive (optional callback) with existing non-streaming flows retained.
> 
> **Overview**
> Adds first-class *streaming token callbacks* across the SDK by threading an optional `on_delta: Callable[[str], None]` through `ask_question`, `ask_single_question`, `process_query`, and `ask_with_persistent_session` for Anthropic, OpenAI, and Gemini; when provided, clients stream deltas to the callback instead of printing, while preserving existing non-streaming behavior.
> 
> Introduces new streaming examples: a FastAPI SSE app (`/ask/stream`) that forwards `on_delta` chunks to clients, and a CLI script demonstrating basic, persistent-session, and chunk-collection streaming; also bumps package version to `1.0.0-pre15` (and lockfile rc version) and downgrades some tool-call logging verbosity (`info`→`debug`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8e3a9ce8c334c430155e6c5a0d1e3fb08f6632e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->